### PR TITLE
Fixed the bulleted list in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Releases can be found here: https://github.com/Flaxbeard/Thaumic_Exploration/rel
 Thaumic Exploration is a WIP add-on for Thaumcraft 4 that adds a variety of new content. Currently, Thaumic Exploration is in early alpha. 
 
 Current content includes:
--Rotten flesh purification
--Zombie brain purification, used in Advanced Golems.
--Binding seals for Warded Jars and Chests. These seals allow the player to create networks of jars or chests with shared inventories.
--Amber wand core, an advanced regenerative wand core.
--Transmutative wand core, a wand core that tries to even out collected vis.
+
+ - Rotten flesh purification
+ - Zombie brain purification, used in Advanced Golems.
+ - Binding seals for Warded Jars and Chests. These seals allow the player to create networks of jars or chests with shared inventories.
+ - Amber wand core, an advanced regenerative wand core.
+ - Transmutative wand core, a wand core that tries to even out collected vis.


### PR DESCRIPTION
Github's markdown implementation is finicky - it's weirdly reliant on whitespace being in the correct place.
